### PR TITLE
Use Control.Monad directly instead of deprecated MTL reexports

### DIFF
--- a/src/Collisions.hs
+++ b/src/Collisions.hs
@@ -2,7 +2,8 @@ module Collisions (
     checkCollisions,
 ) where
 
-import           Control.Monad.State (StateT, get, liftIO, put, when)
+import           Control.Monad       (when)
+import           Control.Monad.State (StateT, get, liftIO, put)
 import qualified SDL
 import qualified SDL.Mixer
 

--- a/src/Game.hs
+++ b/src/Game.hs
@@ -4,8 +4,8 @@ module Game (
     initGame,
 ) where
 
-import           Control.Monad.State (StateT, get, gets, liftIO, modify, put,
-                                      replicateM, unless, when)
+import           Control.Monad       (replicateM, unless, when)
+import           Control.Monad.State (StateT, get, gets, liftIO, modify, put)
 import qualified SDL
 import qualified SDL.Mixer
 

--- a/src/GameFPS.hs
+++ b/src/GameFPS.hs
@@ -4,7 +4,8 @@ module GameFPS (
     fpsDelay,
 ) where
 
-import           Control.Monad.State (StateT, get, liftIO, modify, put, when)
+import           Control.Monad       (when)
+import           Control.Monad.State (StateT, get, liftIO, modify, put)
 import qualified SDL
 
 import           GameConfig          (frameDelay, frameDelayMax)

--- a/src/GameMusic.hs
+++ b/src/GameMusic.hs
@@ -3,7 +3,8 @@ module GameMusic (
     toggleMusic,
 ) where
 
-import           Control.Monad.State (StateT, get, gets, put, when)
+import           Control.Monad       (when)
+import           Control.Monad.State (StateT, get, gets, put)
 import qualified SDL.Mixer
 
 import           GameTypes


### PR DESCRIPTION
Those were removed in mtl-2.3